### PR TITLE
[28] Add workaround for folio boundwith holdings

### DIFF
--- a/src/main/java/edu/tamu/app/service/GetItForMeService.java
+++ b/src/main/java/edu/tamu/app/service/GetItForMeService.java
@@ -231,7 +231,7 @@ public class GetItForMeService {
 
                 //temporary workaround for FOLIO 'boundwith' records whose holdings have 0 items
                 //we'll fake an item with the properties we want
-                if (catalogName.equals("folio") && this.boundWithLocations.length() > 0) {
+                if (catalogName.equals("folio") && holding.getCatalogItems().size() == 0 && this.boundWithLocations.length() > 0) {
                     List<String> boundWithLocationsList = Arrays.asList(this.boundWithLocations.split(";"));
                     if (boundWithLocationsList.contains(holding.getFallbackLocationCode())) {
                         logger.debug("Using BoundWith override");

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -98,6 +98,9 @@ app.defaultButton.text: Get It: 4 days
 app.defaultButton.action: https://getitforme.library.tamu.edu/illiad/EvansLocal/openurl.asp
 app.defaultButton.threshold: 200
 ################################################################
+################################################################
+# Configuration for FOLIO Bound With workaround
+app.boundWith.locations: stk;blcc,stk;BookStacks;psel,stk
 
 ################################################################
 # Configuration for the buttons kill switch

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -88,6 +88,9 @@ app.defaultButton.text: Get It: 4 days
 app.defaultButton.action: https://getitforme.library.tamu.edu/illiad/EvansLocal/openurl.asp
 app.defaultButton.threshold: 200
 ################################################################
+################################################################
+# Configuration for FOLIO Bound With workaround
+app.boundWith.locations: stk;blcc,stk;BookStacks;psel,stk
 
 ################################################################
 # Configuration for the buttons kill switch


### PR DESCRIPTION
Resolves #28 

Creates a synthetic item to enable button analysis when a FOLIO boundwith holding is encountered.