### PR TITLE
[5] add map link endpoint/service

### DIFF
--- a/src/main/java/edu/tamu/app/controller/GetItForMeController.java
+++ b/src/main/java/edu/tamu/app/controller/GetItForMeController.java
@@ -19,6 +19,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import edu.tamu.app.model.ButtonPresentation;
 import edu.tamu.app.service.GetItForMeService;
+import edu.tamu.app.service.MapService;
 import edu.tamu.app.service.SfxService;
 import edu.tamu.app.service.TextCallNumberService;
 import edu.tamu.weaver.response.ApiResponse;
@@ -34,6 +35,9 @@ public class GetItForMeController {
 
     @Autowired
     private SfxService sfxService;
+
+    @Autowired
+    private MapService mapService;
 
 	/**
 	 * Provides fully formatted HTML buttons, keyed by item MFHD
@@ -118,5 +122,10 @@ public class GetItForMeController {
             resolverValues.put(k,v.get(0));
         });
         return new ApiResponse(SUCCESS, sfxService.hasFullText(resolverValues));
+    }
+
+    @RequestMapping("/get-map-link")
+    public ApiResponse getMapLink(@RequestParam("location") String location) {
+        return new ApiResponse(SUCCESS, "Map Link", mapService.getMapLink(location));
     }
 }

--- a/src/main/java/edu/tamu/app/service/MapService.java
+++ b/src/main/java/edu/tamu/app/service/MapService.java
@@ -1,0 +1,35 @@
+package edu.tamu.app.service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Service;
+
+/**
+ * The MapService returns record location details
+ *
+ * @author Jason Savell <jsavell@library.tamu.edu>
+ *
+ */
+
+@Service
+@ConfigurationProperties("mapDetails")
+@PropertySource("classpath:mapDetails.properties")
+public class MapService {
+
+    public final Map<String, String> mapLinks = new HashMap<String,String>();
+
+    public Map<String, String> getMapLinks() {
+        return mapLinks;
+    }
+
+    public String getMapLink(String location) {
+        if (getMapLinks().containsKey(location.toLowerCase())) {
+            return getMapLinks().get(location);
+        }
+        return getMapLinks().get("default");
+
+    }
+}

--- a/src/main/java/edu/tamu/app/service/SfxService.java
+++ b/src/main/java/edu/tamu/app/service/SfxService.java
@@ -4,8 +4,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;

--- a/src/main/resources/mapDetails.properties
+++ b/src/main/resources/mapDetails.properties
@@ -1,0 +1,12 @@
+mapDetails.mapLinks.cushing: https://library.tamu.edu/about/directions/cushing-library.html
+mapDetails.mapLinks.west: https://library.tamu.edu/about/directions/west-campus-library.html
+mapDetails.mapLinks.business: https://library.tamu.edu/about/directions/business-library.html
+mapDetails.mapLinks.policy: https://library.tamu.edu/about/directions/policy-sciences-economics-library.html
+mapDetails.mapLinks.qatar: https://qatar.library.tamu.edu
+mapDetails.mapLinks.turkey: http://nauticalarch.org/ina-turkey
+mapDetails.mapLinks.architecture: http://aggiemap.tamu.edu/index.html?bldg=0398
+mapDetails.mapLinks.halbouty: http://aggiemap.tamu.edu/index.html?bldg=0490
+mapDetails.mapLinks.townes: http://aggiemap.tamu.edu/index.html?bldg=0297
+mapDetails.mapLinks.chiara: http://studyabroad.tamu.edu
+#Don't change this key
+mapDetails.mapLinks.default: https://library.tamu.edu/404.html


### PR DESCRIPTION
This is an initial pass for the Map It! functionality described here: https://github.com/TAMULib/GIFMButtonService/issues/5

It adds an endpoint at "catalog-access/get-map-link/?location=west" to get map urls.

The map urls for now are driven by a spring properties file.