### PR TITLE
Fix incorrect java -jar command and add "repackage" goal.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,4 +59,4 @@ WORKDIR $HOME_DIR
 COPY --from=maven $SOURCE_DIR/target/ROOT.jar ./gifmbutton-service.jar
 
 # Run java command.
-CMD ["java", "-jar", "/gifmbutton-service.jar"]
+CMD ["java", "-jar", "./gifmbutton-service.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,13 @@
           <source>${java.version}</source>
           <target>${java.version}</target>
         </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
The repackage is necessary to fix "no main manifest attribute, in ./ROOT.jar" error.