### PR TITLE
Make callNumberPrefix available as a button parameter

### DIFF
--- a/src/main/java/edu/tamu/app/model/CatalogHolding.java
+++ b/src/main/java/edu/tamu/app/model/CatalogHolding.java
@@ -29,6 +29,7 @@ public class CatalogHolding {
     private String oclc;
     private String recordId;
     private String callNumber;
+    private String callNumberPrefix;
     private boolean largeVolume = false;
 
     private Map<String, Map<String, String>> catalogItems = new HashMap<String, Map<String, String>>();
@@ -37,7 +38,7 @@ public class CatalogHolding {
 
     public CatalogHolding(String marcRecordLeader, String mfhd, String issn, String isbn, String title, String author,
             String publisher, String place, String year, String genre, String edition, String fallBackLocationCode, String oclc, String recordId, String callNumber,
-            Map<String, Map<String, String>> catalogItems) {
+            String callNumberPrefix, Map<String, Map<String, String>> catalogItems) {
         this.setMarcRecordLeader(marcRecordLeader);
         this.setMfhd(mfhd);
         this.setCatalogItems(catalogItems);
@@ -54,12 +55,13 @@ public class CatalogHolding {
         this.setOclc(oclc);
         this.setRecordId(recordId);
         this.setCallNumber(callNumber);
+        this.setCallNumberPrefix(callNumberPrefix);
     }
 
     public CatalogHolding(String marcRecordLeader, String mfhd, String issn, String isbn, String title, String author,
             String publisher, String place, String year, String genre, String edition, String fallBackLocationCode, String oclc, String recordId, String callNumber,
-            boolean largeVolume, Map<String, Map<String, String>> catalogItems) {
-        this(marcRecordLeader, mfhd, issn, isbn, title, author, publisher, place, year, genre, edition, fallBackLocationCode, oclc, recordId, callNumber, catalogItems);
+            String callNumberPrefix, boolean largeVolume, Map<String, Map<String, String>> catalogItems) {
+        this(marcRecordLeader, mfhd, issn, isbn, title, author, publisher, place, year, genre, edition, fallBackLocationCode, oclc, recordId, callNumber, callNumberPrefix, catalogItems);
         this.setLargeVolume(largeVolume);
     }
 
@@ -181,6 +183,14 @@ public class CatalogHolding {
 
     public void setCallNumber(String callNumber) {
         this.callNumber = callNumber;
+    }
+
+    public String getCallNumberPrefix() {
+        return callNumberPrefix;
+    }
+
+    public void setCallNumberPrefix(String callNumberPrefix) {
+        this.callNumberPrefix = callNumberPrefix;
     }
 
     public Map<String, Map<String, String>> getCatalogItems() {

--- a/src/main/resources/buttons.properties
+++ b/src/main/resources/buttons.properties
@@ -13,8 +13,8 @@ CushingButton.locationCodes=cush
 #CushingButton.itemStatusCodes=
 CushingButton.linkText=Request From Cushing
 CushingButton.SID=cushing
-CushingButton.templateParameterKeys=sid,title,author,isxn,publisher,genre,callNumber,location,year,edition
-CushingButton.templateUrl=aeon.library.tamu.edu/aeonnew/openurl.asp?sid={sid}&title={title}&author={author}&ItemISxN={isxn}&publisher={publisher}&genre={genre}&callnumber={callNumber}&location={location}&ItemDate={year}&ItemVolume={edition}
+CushingButton.templateParameterKeys=sid,title,author,isxn,publisher,genre,callNumber,callNumberPrefix,location,year,edition
+CushingButton.templateUrl=aeon.library.tamu.edu/aeonnew/openurl.asp?sid={sid}&title={title}&author={author}&ItemISxN={isxn}&publisher={publisher}&genre={genre}&callnumber={callNumberPrefix}{callNumber}&location={location}&ItemDate={year}&ItemVolume={edition}
 CushingButton.cssClasses=btn_cushing
 CushingButton.catalog=evans
 
@@ -203,8 +203,8 @@ CushingButtonFolio.locationCodes=cush
 #CushingButtonFolio.itemStatusCodes=
 CushingButtonFolio.linkText=Request From Cushing
 CushingButtonFolio.SID=cushing
-CushingButtonFolio.templateParameterKeys=title,author,isxn,publisher,genre,callNumber,location,year,edition
-CushingButtonFolio.templateUrl=aeon.library.tamu.edu/aeonnew/openurl.asp?&title={title}&author={author}&ItemISxN={isxn}&publisher={publisher}&genre={genre}&callnumber={callNumber}&location={location}&ItemDate={year}&ItemVolume={edition}
+CushingButtonFolio.templateParameterKeys=title,author,isxn,publisher,genre,callNumber,callNumberPrefix,location,year,edition
+CushingButtonFolio.templateUrl=aeon.library.tamu.edu/aeonnew/openurl.asp?&title={title}&author={author}&ItemISxN={isxn}&publisher={publisher}&genre={genre}&callnumber={callNumberPrefix}{callNumber}&location={location}&ItemDate={year}&ItemVolume={edition}
 CushingButtonFolio.cssClasses=btn_cushing
 CushingButtonFolio.catalog=folio
 


### PR DESCRIPTION
# Description

This PR enables the [Call Number prefix](https://github.com/TAMULib/CatalogService/pull/196) to be used as a button parameter.

It also adds this prefix as a parameter to the Cushing buttons for new deployments. Existing deployments would need to have the buttons updated through the administrative UI.

This PR is dependent on the corresponding [Catalog Service PR](https://github.com/TAMULib/CatalogService/pull/196) and has not been tested against real world data.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This PR builds and existing tests pass, but they also don't cover this change.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

