### PR TITLE
Fix for sfx template being unavailable in jar context

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>edu.tamu</groupId>
   <artifactId>gifmbutton-service</artifactId>
-  <version>2.8.0</version>
+  <version>2.8.1-RC1</version>
 
   <name>GIFM Button-Service</name>
 

--- a/src/main/java/edu/tamu/app/service/SfxService.java
+++ b/src/main/java/edu/tamu/app/service/SfxService.java
@@ -71,7 +71,7 @@ public class SfxService {
 
     private String getXmlTemplate() throws IOException {
         if (this.xmlTemplate == null) {
-            this.xmlTemplate =  Files.readString(resourceLoader.getResource("classpath:templates/sfx_rft.xml").getFile().toPath());
+            this.xmlTemplate =  new String(resourceLoader.getResource("classpath:templates/sfx_rft.xml").getInputStream().readAllBytes());
         }
         return this.xmlTemplate;
     }


### PR DESCRIPTION
# Description

The template xml for the SFX api request was not being loaded when the app was deployed as a jar. This fix allows the template to be loaded regardless of deployment type.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested via local spring-boot:run and jar and dev deployment.

