### PR TITLE
Redirect to Public Catalog for multi-button scenarios

### DIFF
--- a/src/main/java/edu/tamu/app/controller/GetItForMeController.java
+++ b/src/main/java/edu/tamu/app/controller/GetItForMeController.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import org.apache.http.HttpStatus;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -156,8 +157,16 @@ public class GetItForMeController {
             //to the other button if there are only 2 or fewer holdings
             Integer holdingCountThreshold = (hasCushing) ? 3:2;
 
+            // we can only redirect to the catalog if we have an hrid, not a uuid
+            boolean bibIdIsUUID = true;
+            try {
+                bibIdIsUUID = (UUID.fromString(bibId).toString().equals(bibId));
+            } catch (IllegalArgumentException e) {
+                bibIdIsUUID = false;
+            }
+
             //If we have too many holdings options to choose from, redirect to the catalog so the user can choose there
-            if ((!hasCushing || !wantsCushing) && holdingsWithButtonsCount >= holdingCountThreshold && publicCatalogUrl.length() > 0) {
+            if (!bibIdIsUUID && (!hasCushing || !wantsCushing) && holdingsWithButtonsCount >= holdingCountThreshold && publicCatalogUrl.length() > 0) {
                 redirectUrl = publicCatalogUrl + bibId;
             }
 

--- a/src/main/java/edu/tamu/app/controller/GetItForMeController.java
+++ b/src/main/java/edu/tamu/app/controller/GetItForMeController.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 import org.apache.http.HttpStatus;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,6 +27,9 @@ import edu.tamu.weaver.response.ApiResponse;
 @RestController
 @RequestMapping("/catalog-access")
 public class GetItForMeController {
+
+    @Value("${app.publicCatalogUrl:}")
+    private String publicCatalogUrl;
 
     @Autowired
     private GetItForMeService getItForMeService;
@@ -79,45 +83,86 @@ public class GetItForMeController {
         }
     }
 
+    private boolean testIsCushing(Map<String, String> button) {
+        boolean cssClassIsCushing = button.get("cssClasses") != null && button.get("cssClasses").contains("btn_cushing");
+        boolean linkHrefIsCushing = button.get("linkHref") != null && button.get("linkHref").contains("aeon.library.tamu.edu");
+        return cssClassIsCushing && linkHrefIsCushing;
+    }
+
+    private String buildRedirectUrl(String baseUrl) {
+        return baseUrl.startsWith("http") ? baseUrl : "https://" + baseUrl;
+    }
+
+    private String ensureBibId(String id) {
+        String bibId = id;
+        //if we have the prefix, we need to remove it and convert the uuid to dash format
+        String bibIdPrefix = "tamu.";
+        if (bibId.startsWith(bibIdPrefix)) {
+            String[] uuidPieces = bibId.split(bibIdPrefix, 0);
+            bibId = uuidPieces[1].replace(".", "-");
+        }
+        return bibId;
+    }
+
     /**
      * Provides the raw button data in JSON format, keyed by MFHD.
      * If a specific button with matching criteria - Cushing is found, it performs a redirect.
      * @param String catalogName Optional catalog name. Defaults to "evans" if not provided.
-     * @param String bibId  Required bibliographic ID. It used to retrieve holdings and associated button data.
-     * @param boolean verbose.
+     * @param String bibId  Required bibliographic ID (UUID, hrid, or EBSCO format). Used to retrieve holdings and associated button data.
      * @param String location Optional location parameter used for location-based redirect.
      * @return ApiResponse or RedirectView based on redirectUrl.
      */
     @RequestMapping("/get-buttons-redirect")
-    public Object getButtonsRedirectByBibId(@RequestParam(value="catalogName",defaultValue="evans") String catalogName, @RequestParam("bibId") String bibId, @RequestParam(value="verbose",defaultValue="false") boolean verbose, @RequestParam(value="location", required = false, defaultValue="") String location) {
-
-        Map<String,ButtonPresentation> buttonData = getItForMeService.getButtonDataByBibId(catalogName, bibId, verbose);
+    public Object getButtonsRedirectByBibId(@RequestParam(value="catalogName",defaultValue="evans") String catalogName, @RequestParam("bibId") String bibId, @RequestParam(value="location", required = false, defaultValue="") String location) {
+        bibId = ensureBibId(bibId);
+        Map<String,ButtonPresentation> buttonData = getItForMeService.getButtonDataByBibId(catalogName, bibId);
         String redirectUrl = null;
         if (buttonData != null) {
+            //test for the button set having a Cushing button
+            boolean hasCushing = false;
+            //test for the user requesting a Cushing button
+            boolean wantsCushing = location.equalsIgnoreCase("aeon");
+            Integer holdingsWithButtonsCount = 0;
+
             for (Map.Entry<String, ButtonPresentation> entry : buttonData.entrySet()) {
                 String holdingId = entry.getKey();
                 ButtonPresentation buttonPresentation = entry.getValue();
                 if (holdingId != null && buttonPresentation != null && buttonPresentation.getButtons() != null) {
+                    holdingsWithButtonsCount++;
                     for( Map<String, String> button: buttonPresentation.getButtons()) {
-                        String cssClass = button.get("cssClasses");
                         String linkHref = button.get("linkHref");
-                        boolean isCushing = ( cssClass != null && cssClass.contains("btn_cushing") ) &&
-                                            ( linkHref != null && linkHref.contains("aeon.library.tamu.edu") );
-
-                        if(isCushing && location.equalsIgnoreCase("aeon") && linkHref != null ) {
-                            redirectUrl = linkHref.startsWith("http") ? linkHref : "https://" + linkHref;
+                        //is the current button Cushing
+                        boolean isCushing = testIsCushing(button);
+                        //is at least one button in the set Cushing
+                        if (isCushing && !hasCushing) {
+                            hasCushing = true;
+                        }
+                        //when the user wants Cushing, grab the url of the first button that is for Cushing
+                        if(redirectUrl == null && isCushing && wantsCushing && linkHref != null ) {
+                            redirectUrl = buildRedirectUrl(linkHref);
                             break;
                         }
-
-                        if(!isCushing && location.equalsIgnoreCase("illiad") && linkHref != null ) {
-                            redirectUrl = linkHref.startsWith("http") ? linkHref : "https://" + linkHref;
+                        //when the user doesn't want Cushing, grab the first button that isn't Cushing
+                        if(redirectUrl == null && !isCushing && !wantsCushing && linkHref != null ) {
+                            redirectUrl = buildRedirectUrl(linkHref);
                             break;
                         }
                     }
                 }
-                if(redirectUrl != null) {
-                  return new RedirectView(redirectUrl);
-                }
+                //complete the whole button set loop even if we have a redirectUrl so we can learn if we have
+                //a Cushing button in the set or not and our total count of holdings with buttons
+            }
+            //if we have a Cushing button but the user hasn't explicitly requested one, we can auto-redirect
+            //to the other button if there are only 2 or fewer holdings
+            Integer holdingCountThreshold = (hasCushing) ? 3:2;
+
+            //If we have too many holdings options to choose from, redirect to the catalog so the user can choose there
+            if ((!hasCushing || !wantsCushing) && holdingsWithButtonsCount >= holdingCountThreshold && publicCatalogUrl.length() > 0) {
+                redirectUrl = publicCatalogUrl + bibId;
+            }
+
+            if (redirectUrl != null) {
+                return new RedirectView(redirectUrl);
             }
             throw new ResponseStatusException(HttpStatus.SC_NOT_FOUND, "No valid redirect URL found.", null);
         } else {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -123,7 +123,10 @@ app:
     timeout: 10000
 
   # Catalog Service location *requires trailing forward slash
-  catalogServiceUrl: https://api-dev.library.tamu.edu/catalog/3x/
+  catalogServiceUrl: https://api-dev.library.tamu.edu/catalog/3x/catalog-access/
+
+  # Base URL for the public facing catalog single record view
+  publicCatalogUrl: https://catalog-dev.library.tamu.edu/Record/
 
   # Catalog Configuration file
   catalogsConfiguration:


### PR DESCRIPTION
When using the redirect endpoint and there are multiple GIFM options, redirect to the public catalog so the user can select the appropriate option.

This has been thoroughly tested in pre-production by the Discovery and GIFM teams over the last three months.