### PR TITLE
Switch JRE image from openjdk to eclipse.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ USER $USER_NAME
 RUN mvn package -Pjar -DskipTests=true
 
 # Switch to Normal JRE Stage.
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:11-jre-noble
 ARG USER_ID
 ARG USER_NAME
 ARG SOURCE_DIR


### PR DESCRIPTION
`openjdk:11-jre-slim` no longer exists.